### PR TITLE
Fix comment spelling

### DIFF
--- a/limitless.rb
+++ b/limitless.rb
@@ -159,7 +159,7 @@ def json_to_md(json_path)
   markdown = ll["markdown"]
   raise "No markdown field present in lifelog #{id}." if markdown.nil? || markdown.empty?
 
-  # Normalise newlines to \n for consistency
+  # Normalize newlines to \n for consistency
   content = markdown.gsub(/\r?\n/, "\n")
   File.write(md_path, content)
   md_path


### PR DESCRIPTION
## Summary
- correct a spelling error in a comment

## Testing
- `ruby -c limitless.rb`